### PR TITLE
Performance improvements

### DIFF
--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -14,6 +14,7 @@
 
 from copy import deepcopy
 from functools import lru_cache, partial
+import pickle
 import time
 
 import singer
@@ -740,7 +741,8 @@ class SQLInterface:
 
         for record in records:
 
-            row = deepcopy(default_row)
+            ## pickling/unpickling is much faster than deepcopy
+            row = pickle.loads(pickle.dumps(default_row))
 
             for path in paths:
                 json_schema_string_type, value = record.get(path, (None, None))


### PR DESCRIPTION
Initially posted as https://github.com/datamill-co/target-postgres/pull/204.

This PR addresses the changes proposed in https://github.com/datamill-co/target-postgres/issues/203

As described in the issue, loading data seemed unnecessarily slow. On a test CSV file containing 50k rows, each with 2 cols of fixed length text, target-postgres was spending about 20 seconds loading the data.

Some profiling helped identify the bottlenecks, as described in the issue.

This PR proposes 3 distinct improvements, in decreasing order of time savings (based on my test case). With cProfile instrumentation, the loading took approx 32 seconds instead of 20:

    There is only a limited combination of arguments to _serialize_table_record_field_name so that it can be cached to avoid recalculating over and over. The method was called for each field of each row, including all 5 metadata fields. In my example, this led to about 350k calls. With functools.lru_cache applied, cache_info showed that only 7 calls were really made, all remaining calls resulted in cache hits. My test data is extremely consistent, so might be a best case, but my understanding is that this should result in at most number_of_fields * possible_data_types actual calls. If multiple batches are required to load the data, each batch will recreate a fresh cache. My fix to allow caching feels a bit hackish, but it seems to work (improvement suggestions welcome!). This saves about 15s/32 (with profiling on).
    The same seems to apply to serialize_table_record_datetime_value (in my tests, each record has the same value in _sdc_batched_at). The call to arrow is pretty expensive. In my testing, the exact same value was formatted once per row. Applying caching on this seems straightforward. In my sample, it led to about 14s/32 of time savings.
    The last bit of excessive time is spent in deepcopy which is a weirdly slow function. Replacing it with pickling/unpickling saved about 1.5s again.

In the end, with these speedups applied, the same data now loads in under 4s instead of the original 20s.